### PR TITLE
GR-1154: Fix compile issue in OSRM Storage

### DIFF
--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -55,7 +55,6 @@ struct RegionHandle
         return oss.str();
     }
 };
-inline std::ostream& operator<<(std::ostream& os, const RegionHandle& r) { return os << r.ToString(); }
 
 RegionHandle setupRegion(SharedRegionRegister &shared_register,
                          const storage::BaseDataLayout &layout)


### PR DESCRIPTION
Remove an unused operator in `storage.cpp` that generates a compile error.